### PR TITLE
feat: add OpenEXR output support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A Rust CLI tool and library for converting HDR gain map images to HDR10 AVIF. Supports two input formats:
+A Rust CLI tool and library for converting HDR gain map images to HDR10 AVIF or OpenEXR. Supports two input formats:
 
 - **Ultra HDR JPEG** - Google's format for embedding HDR gain maps in standard JPEG files
 - **Apple HDR HEIC** - Apple's HDR gain map format used by iPhone (requires `heif` feature)
 
-The tool extracts the gain map, computes the HDR rendition, and encodes to 10-bit PQ AVIF in BT.2020 color space.
+The tool extracts the gain map, computes the HDR rendition, and encodes to either 10-bit PQ AVIF or BT.2020 linear float OpenEXR (nits).
 
 ## Language
 
@@ -39,10 +39,11 @@ cargo test -F avif,heif --package libuhdr --lib -- apple_hdr
 ### Workspace Structure
 
 - **`crates/uhdr2avif`** - CLI binary using clap for argument parsing
+  - `exr` (default) - Enables OpenEXR output support (forwards to `libuhdr/exr`)
   - `heif` feature - Enables Apple HDR HEIC input support (forwards to `libuhdr/heif`)
 - **`crates/libuhdr`** - Core library with optional feature flags:
-  - `avif` (default) - AVIF output via ravif/rav1e
-  - `exr` - EXR output support
+  - `avif` (default) - AVIF output via rav1e/avif-serialize
+  - `exr` - OpenEXR output support via exr crate
   - `heif` - Apple HDR HEIC input support via libheif-rs
 
 ### Ultra HDR JPEG Pipeline
@@ -52,13 +53,15 @@ cargo test -F avif,heif --package libuhdr --lib -- apple_hdr
 3. **Metadata Parsing** (`uhdr/gainmap.rs`) - Extracts HDR parameters from XMP: gamma, gain_map_min/max, offset_sdr/hdr, hdr_capacity_min/max
 4. **HDR Boost Computation** (`uhdr.rs:UhdrBoostComputer`) - Applies the Ultra HDR algorithm to compute boosted HDR values from SDR + gain map
 5. **Color Space Conversion** (`colorspace.rs`) - Converts from source gamut (typically sRGB from ICC profile) to BT.2020
-6. **AVIF Encoding** (`outavif.rs`) - Converts linear RGB to PQ-encoded Y'CbCr and writes 10-bit HDR10 AVIF
+6. **Output Encoding**:
+   - **AVIF** (`outavif.rs`) - Converts linear RGB to PQ-encoded Y'CbCr, encodes AV1 via rav1e, and writes 10-bit HDR10 AVIF with EXIF passthrough via avif-serialize
+   - **EXR** (`outexr.rs`, `exr` feature) - Writes BT.2020 linear float RGB (nits) with chromaticity metadata and PIZ compression
 
 ### Apple HDR HEIC Pipeline (`heif` feature)
 
 1. **HEIC Parsing** (`apple_hdr/heic.rs`) - Uses `libheif-rs` to decode HEIC, extract SDR image (linearized with sRGB EOTF), gain map (Rec.709 EOTF), and color gamut (NCLX/ICC)
 2. **Headroom Extraction** (`apple_hdr/heic.rs`) - Parses Apple MakerNote from EXIF (tags 0x0021/0x0030) via the TIFF IFD parser (`tiff.rs`) to compute HDR headroom
-3. **HDR Boost** (`apple_hdr.rs:AppleHdrHeicConverter`) - Applies `sdr * (1 + (headroom - 1) * gainmap)`, converts gamut to BT.2020, encodes to AVIF
+3. **HDR Boost** (`apple_hdr.rs:AppleHdrHeicConverter`) - Applies `sdr * (1 + (headroom - 1) * gainmap)`, converts gamut to BT.2020, encodes to AVIF or EXR
 
 ### Key Types
 
@@ -73,4 +76,4 @@ cargo test -F avif,heif --package libuhdr --lib -- apple_hdr
 
 ### External Dependencies Note
 
-The project uses a forked version of `ravif` with a custom `encode_raw_plane_10_with_params` method for HDR10 encoding with explicit color parameters. The `zune-jpeg` dependency requires a specific git revision that supports `multi_picture_information` for MPF parsing. The `libheif-rs` dependency uses a specific git revision for HEIC decoding.
+AVIF encoding uses `rav1e` (AV1 encoder) and `avif-serialize` (AVIF container serialization) directly, without the `ravif` wrapper. This allows direct control over EXIF passthrough via `avif_serialize::Aviffy::set_exif()`. EXR encoding uses the `exr` crate; its writer requires `Write + Seek` so stdout is not supported for EXR output. The `zune-jpeg` dependency requires a specific git revision that supports `multi_picture_information` for MPF parsing. The `libheif-rs` dependency uses a specific git revision for HEIC decoding.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # `uhdr2avif`
 
-**CLI tool and core library written in 🦀Rust for converting HDR gain map images to HDR10 AVIF**
+**CLI tool and core library written in 🦀Rust for converting HDR gain map images to HDR10 AVIF or OpenEXR**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -18,11 +18,6 @@ CLI tool binary [releases](https://github.com/James2022-rgb/uhdr2avif/releases) 
 - macOS ARM: `aarch64-apple-darwin`
 - macOS Intel: `x86_64-apple-darwin`
 
-## ~~⚠️ Work-in-progress~~
-~~This is a work-in-progress PoC, and is currently a lot slower that it could be~~.
-
-It mostly does its originally intended job now, and while there are many potentials for optimization, the AV1 encoding in `rav1e` seems to take up the vast majority of the CLI binary's runtime.
-
 ## 📥 Supported Input Formats
 
 | Format | Description | Feature flag |
@@ -30,22 +25,33 @@ It mostly does its originally intended job now, and while there are many potenti
 | [Ultra HDR](https://developer.android.com/media/platform/hdr-image-format) JPEG | Google's HDR gain map format embedded in standard JPEG | _(always enabled)_ |
 | [Apple HDR](https://developer.apple.com/documentation/appkit/applying-apple-hdr-effect-to-your-photos) HEIC | Apple's HDR gain map format used by iPhone | `heif` |
 
-The input format is auto-detected from the file extension (`.jpg`/`.jpeg` or `.heic`), or can be explicitly specified with `--format`.
+The input format is auto-detected from the file extension (`.jpg`/`.jpeg` or `.heic`), or can be explicitly specified with `--input-format`.
 
-## 📦 The CLI tool binary
+## 📤 Supported Output Formats
 
-`uhdr2avif` is a command-line tool that converts HDR gain map images to AVIF, preserving HDR (High Dynamic Range) with optional tonemapping controls.
+| Format | Description | Feature flag |
+|--------|-------------|-------------|
+| [HDR10](https://en.wikipedia.org/wiki/HDR10) AVIF | 10-bit PQ BT.2020 AVIF | _(always enabled)_ |
+| [OpenEXR](https://openexr.com/) | BT.2020 linear float (nits) | `exr` (default) |
+
+The output format is auto-detected from the output file extension (`.avif` or `.exr`), or can be explicitly specified with `--output-format`.
+
+## 📦 CLI Tool Binary
+
+`uhdr2avif` is a command-line tool that converts HDR gain map images to AVIF or OpenEXR, preserving HDR (High Dynamic Range) with optional tonemapping controls.
 
 ### Command line options
 
 #### Input
 - Accepts a file path via `--input` / `-i`, or raw data via `--stdin`.
 - If `--input` is not provided, the program reads from stdin only if `--stdin` is explicitly set.
-- `--format` / `-f` can be used to explicitly specify the input format (`jpeg` or `heic`). If omitted, the format is detected from the file extension.
+- `--input-format` / `-I` can be used to explicitly specify the input format (`jpeg` or `heic`). If omitted, the format is detected from the file extension.
 
 #### Output
 - Writes to a file path specified via `--output` / `-o`, or to stdout if `--stdout` is set.
 - If `--output` is not provided, the program writes to stdout only if `--stdout` is explicitly set.
+- `--output-format` / `-F` can be used to explicitly specify the output format (`avif` or `exr`). If omitted, the format is detected from the output file extension. When writing to stdout without an explicit format, AVIF is used by default.
+- **Note:** EXR output requires a file path and does not support stdout (the EXR format requires seekable output).
 
 #### HDR parameters
 - `--max-display-boost`, defaulting to `10`, specifies maximum available boost supported by a display, as described in [Ultra HDR Image Format v1.1](https://developer.android.com/media/platform/hdr-image-format#definitions). This constant determines the strength of the Ultra HDR _HDR rendition_.
@@ -72,12 +78,14 @@ Options:
           The input file to process. If not specified, the program will read from stdin if `--stdin` is enabled
       --stdin
           Read input from stdin if true
-  -f, --format <FORMAT>
+  -I, --input-format <INPUT_FORMAT>
           Input format. If omitted, detected from file extension [possible values: jpeg, heic]
   -o, --output <OUTPUT_FILE_PATH>
           The output file to write to
       --stdout
           Write output to stdout if true. If not specified, the program will write to stdout if `--stdout` is provided
+  -F, --output-format <OUTPUT_FORMAT>
+          Output format. If omitted, detected from output file extension [possible values: avif, exr]
       --max-display-boost <MAX_DISPLAY_BOOST>
           The maximum available boost supported by a display, at a given point in time. This is a constant value that should be set based on the display's capabilities. This value is used to compute the boosted Ultra HDR "HDR rendition" value [default: 10]
       --target-sdr-white-level <TARGET_SDR_WHITE_LEVEL>
@@ -90,4 +98,5 @@ Options:
           Print version
 ```
 
-> **Note:** The `heic` format option is only available when built with the `heif` feature (`cargo build -F heif`).
+> **Note:** The `heic` input format option is only available when built with the `heif` feature (`cargo build -F heif`).
+> The `exr` output format option is available by default and can be disabled with `--no-default-features`.

--- a/crates/libuhdr/src/apple_hdr.rs
+++ b/crates/libuhdr/src/apple_hdr.rs
@@ -14,13 +14,8 @@ impl AppleHdrHeicConverter {
         Ok(Self { heic })
     }
 
-    #[cfg(feature = "avif")]
-    pub fn convert_to_avif<W: std::io::Write>(
-        &self,
-        writer: &mut W,
-        target_sdr_white_level: f32,
-        preserve_exif: bool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    /// Compute BT.2020 linear nits pixels from the Apple HDR HEIC.
+    fn compute_hdr_linear_pixels(&self, target_sdr_white_level: f32) -> (usize, usize, crate::pixel::FloatImageContent) {
         use crate::colorspace::ColorGamut;
         use crate::pixel::{FloatPixel, FloatImageContent};
 
@@ -66,6 +61,18 @@ impl AppleHdrHeicConverter {
             }
         }
 
+        (width, height, linear_pixels)
+    }
+
+    #[cfg(feature = "avif")]
+    pub fn convert_to_avif<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        target_sdr_white_level: f32,
+        preserve_exif: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (width, height, linear_pixels) = self.compute_hdr_linear_pixels(target_sdr_white_level);
+
         let exif = if preserve_exif {
             self.heic.exif_data_block().map(|raw| {
                 let mut block = raw.to_vec();
@@ -88,6 +95,24 @@ impl AppleHdrHeicConverter {
             &linear_pixels,
             exif.as_deref(),
         ).map_err(|e| format!("Failed to write AVIF: {}", e))?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "exr")]
+    pub fn convert_to_exr<W: std::io::Write + std::io::Seek>(
+        &self,
+        writer: W,
+        target_sdr_white_level: f32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (width, height, linear_pixels) = self.compute_hdr_linear_pixels(target_sdr_white_level);
+
+        crate::outexr::write_hdr10_linear_pixels_to_exr(
+            writer,
+            width,
+            height,
+            &linear_pixels,
+        ).map_err(|e| format!("Failed to write EXR: {}", e))?;
 
         Ok(())
     }

--- a/crates/libuhdr/src/lib.rs
+++ b/crates/libuhdr/src/lib.rs
@@ -13,7 +13,7 @@ pub mod apple_hdr;
 pub mod outavif;
 
 #[cfg(feature = "exr")]
-mod outexr;
+pub mod outexr;
 #[cfg(feature = "heif")]
 mod outheif;
 mod pixel;

--- a/crates/libuhdr/src/outexr.rs
+++ b/crates/libuhdr/src/outexr.rs
@@ -4,28 +4,30 @@ use exr::prelude::*;
 use exr::meta::attribute::Chromaticities;
 
 use crate::colorspace::ColorGamut;
+use crate::pixel::FloatImageContent;
 
-pub fn write_rgb_image_to_exr<F: Fn(usize, usize) -> (f32, f32, f32) + Sync>(
-    filename: &str,
+pub fn write_hdr10_linear_pixels_to_exr<W: std::io::Write + std::io::Seek>(
+    writer: W,
     width: usize,
     height: usize,
-    color_gamut: &ColorGamut,
-    f: F,
+    content: &FloatImageContent,
 ) -> std::io::Result<()> {
-    let primaries = color_gamut.primaries();
+    let bt2020 = ColorGamut::bt2020();
+    let primaries = bt2020.primaries();
 
     let chromaticities = Chromaticities {
         red: Vec2(primaries.red_xy()[0] as f32, primaries.red_xy()[1] as f32),
         green: Vec2(primaries.green_xy()[0] as f32, primaries.green_xy()[1] as f32),
         blue: Vec2(primaries.blue_xy()[0] as f32, primaries.blue_xy()[1] as f32),
-        white: Vec2(color_gamut.white_point_xy()[0] as f32, color_gamut.white_point_xy()[1] as f32),
+        white: Vec2(bt2020.white_point_xy()[0] as f32, bt2020.white_point_xy()[1] as f32),
     };
 
-    let mut image_attributes = ImageAttributes::new(IntegerBounds::from_dimensions((width, height)));  
+    let mut image_attributes = ImageAttributes::new(IntegerBounds::from_dimensions((width, height)));
     image_attributes.chromaticities = Some(chromaticities);
 
     let channels = SpecificChannels::rgb(|Vec2(x, y)| {
-        f(x as usize, y as usize)
+        let pixel = content.get_at(x as usize, y as usize);
+        (pixel.r(), pixel.g(), pixel.b())
     });
 
     let mut image = Image::from_channels((width, height), channels);
@@ -33,7 +35,7 @@ pub fn write_rgb_image_to_exr<F: Fn(usize, usize) -> (f32, f32, f32) + Sync>(
 
     image.layer_data.encoding.compression = Compression::PIZ;
 
-    image.write().to_file(filename).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    
+    image.write().to_unbuffered(writer).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
     Ok(())
 }

--- a/crates/libuhdr/src/uhdr.rs
+++ b/crates/libuhdr/src/uhdr.rs
@@ -68,13 +68,8 @@ impl UhdrConverter {
         })
     }
 
-    #[cfg(feature = "avif")]
-    pub fn convert_to_avif<W: Write>(
-        &self,
-        writer: &mut W,
-        target_sdr_white_level: f32,
-        preserve_exif: bool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    /// Compute BT.2020 linear nits pixels from the Ultra HDR JPEG.
+    fn compute_hdr_linear_pixels(&self, target_sdr_white_level: f32) -> FloatImageContent {
         const DST_COLOR_GAMUT: ColorGamut = ColorGamut::bt2020();
 
         let (width, height) = self.uhdr_jpeg.extent();
@@ -115,6 +110,19 @@ impl UhdrConverter {
             }
         }
 
+        linear_pixels
+    }
+
+    #[cfg(feature = "avif")]
+    pub fn convert_to_avif<W: Write>(
+        &self,
+        writer: &mut W,
+        target_sdr_white_level: f32,
+        preserve_exif: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (width, height) = self.uhdr_jpeg.extent();
+        let linear_pixels = self.compute_hdr_linear_pixels(target_sdr_white_level);
+
         let exif = if preserve_exif {
             self.uhdr_jpeg.exif_bytes().map(|tiff_bytes| {
                 let mut tiff = tiff_bytes.to_vec();
@@ -135,6 +143,25 @@ impl UhdrConverter {
             &linear_pixels,
             exif.as_deref(),
         ).map_err(|e| format!("Failed to write AVIF: {}", e))?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "exr")]
+    pub fn convert_to_exr<W: Write + std::io::Seek>(
+        &self,
+        writer: W,
+        target_sdr_white_level: f32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (width, height) = self.uhdr_jpeg.extent();
+        let linear_pixels = self.compute_hdr_linear_pixels(target_sdr_white_level);
+
+        crate::outexr::write_hdr10_linear_pixels_to_exr(
+            writer,
+            width as usize,
+            height as usize,
+            &linear_pixels,
+        ).map_err(|e| format!("Failed to write EXR: {}", e))?;
 
         Ok(())
     }

--- a/crates/uhdr2avif/Cargo.toml
+++ b/crates/uhdr2avif/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.3.0"
 edition = "2024"
 
 [features]
-default = []
+default = ["exr"]
+exr = ["libuhdr/exr"]
 heif = ["libuhdr/heif"]
 
 [dependencies]

--- a/crates/uhdr2avif/src/main.rs
+++ b/crates/uhdr2avif/src/main.rs
@@ -29,6 +29,15 @@ enum InputFormat {
     Heic,
 }
 
+#[derive(Clone, clap::ValueEnum, Debug)]
+enum OutputFormat {
+    /// HDR10 AVIF output.
+    Avif,
+    /// OpenEXR output (BT.2020 linear nits, float).
+    #[cfg(feature = "exr")]
+    Exr,
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -40,8 +49,8 @@ struct Args {
     #[arg(long="stdin", default_value_t = false)]
     stdin: bool,
     /// Input format. If omitted, detected from file extension.
-    #[arg(short='f', long="format")]
-    format: Option<InputFormat>,
+    #[arg(short='I', long="input-format")]
+    input_format: Option<InputFormat>,
     /// The output file to write to.
     #[arg(short='o', long="output")]
     output_file_path: Option<String>,
@@ -49,6 +58,9 @@ struct Args {
     /// If not specified, the program will write to stdout if `--stdout` is provided.
     #[arg(long="stdout", default_value_t = false)]
     stdout: bool,
+    /// Output format. If omitted, detected from output file extension.
+    #[arg(short='F', long="output-format")]
+    output_format: Option<OutputFormat>,
     /// The maximum available boost supported by a display, at a given point in time.
     /// This is a constant value that should be set based on the display's capabilities.
     /// This value is used to compute the boosted Ultra HDR "HDR rendition" value.
@@ -85,7 +97,33 @@ fn detect_input_format(file_path: &str) -> Result<InputFormat, String> {
                 supported,
             ))
         }
-        None => Err("Input file has no extension. Use --format to specify the input format.".to_string()),
+        None => Err("Input file has no extension. Use --input-format to specify the input format.".to_string()),
+    }
+}
+
+/// Detect the output format from the file extension.
+fn detect_output_format(file_path: &str) -> Result<OutputFormat, String> {
+    let ext = Path::new(file_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+
+    match ext.as_deref() {
+        Some("avif") => Ok(OutputFormat::Avif),
+        #[cfg(feature = "exr")]
+        Some("exr") => Ok(OutputFormat::Exr),
+        Some(ext) => {
+            #[cfg(not(feature = "exr"))]
+            let supported = "avif";
+            #[cfg(feature = "exr")]
+            let supported = "avif, exr";
+            Err(format!(
+                "Unsupported output file extension '.{}'. Supported extensions: {}",
+                ext,
+                supported,
+            ))
+        }
+        None => Err("Output file has no extension. Use --output-format to specify the output format.".to_string()),
     }
 }
 
@@ -94,12 +132,21 @@ fn main() -> Result<(), String> {
 
     let args = Args::parse();
 
-    let input_format = if let Some(format) = args.format {
+    let input_format = if let Some(format) = args.input_format {
         format
     } else {
         let file_path = args.input_file_path.as_deref()
-            .ok_or("Cannot detect input format without a file path. Use --format to specify the input format.")?;
+            .ok_or("Cannot detect input format without a file path. Use --input-format to specify the input format.")?;
         detect_input_format(file_path)?
+    };
+
+    let output_format = if let Some(format) = args.output_format {
+        format
+    } else if let Some(ref file_path) = args.output_file_path {
+        detect_output_format(file_path)?
+    } else {
+        // Default to AVIF when writing to stdout with no explicit format.
+        OutputFormat::Avif
     };
 
     let mut reader: Box<dyn Read> = if let Some(ref input_file_path) = args.input_file_path {
@@ -112,38 +159,73 @@ fn main() -> Result<(), String> {
         return Err("No input file specified and stdin not enabled".to_string());
     };
 
-    let mut writer: Box<dyn Write> = if let Some(output_file_path) = args.output_file_path {
-        trace!("Writing output to file: {}", output_file_path);
-        Box::new(File::create(output_file_path).map_err(|e| format!("Failed to create output file: {}", e))?)
-    } else if args.stdout {
-        trace!("Writing output to stdout");
-        Box::new(std::io::stdout())
-    } else {
-        return Err("No output file specified and stdout not enabled".to_string());
-    };
-
     let target_sdr_white_level = args.target_sdr_white_level;
     let preserve_exif = !args.no_preserve_exif;
 
-    match input_format {
-        InputFormat::Jpeg => {
-            let uhdr_converter = UhdrConverter::new(&mut reader, args.max_display_boost)
-                .map_err(|e| format!("Failed to create UHDR converter: {}", e))?;
+    match output_format {
+        OutputFormat::Avif => {
+            let mut writer: Box<dyn Write> = if let Some(output_file_path) = args.output_file_path {
+                trace!("Writing output to file: {}", output_file_path);
+                Box::new(File::create(output_file_path).map_err(|e| format!("Failed to create output file: {}", e))?)
+            } else if args.stdout {
+                trace!("Writing output to stdout");
+                Box::new(std::io::stdout())
+            } else {
+                return Err("No output file specified and stdout not enabled".to_string());
+            };
 
-            uhdr_converter.convert_to_avif(&mut writer, target_sdr_white_level, preserve_exif)
-                .map_err(|e| format!("Failed to convert UHDR JPEG to AVIF: {}", e))?;
+            match input_format {
+                InputFormat::Jpeg => {
+                    let uhdr_converter = UhdrConverter::new(&mut reader, args.max_display_boost)
+                        .map_err(|e| format!("Failed to create UHDR converter: {}", e))?;
+
+                    uhdr_converter.convert_to_avif(&mut writer, target_sdr_white_level, preserve_exif)
+                        .map_err(|e| format!("Failed to convert UHDR JPEG to AVIF: {}", e))?;
+                }
+                #[cfg(feature = "heif")]
+                InputFormat::Heic => {
+                    let mut bytes = Vec::new();
+                    reader.read_to_end(&mut bytes)
+                        .map_err(|e| format!("Failed to read input: {}", e))?;
+
+                    let converter = AppleHdrHeicConverter::new(&bytes)
+                        .map_err(|e| format!("Failed to create Apple HDR HEIC converter: {}", e))?;
+
+                    converter.convert_to_avif(&mut writer, target_sdr_white_level, preserve_exif)
+                        .map_err(|e| format!("Failed to convert Apple HDR HEIC to AVIF: {}", e))?;
+                }
+            }
         }
-        #[cfg(feature = "heif")]
-        InputFormat::Heic => {
-            let mut bytes = Vec::new();
-            reader.read_to_end(&mut bytes)
-                .map_err(|e| format!("Failed to read input: {}", e))?;
+        #[cfg(feature = "exr")]
+        OutputFormat::Exr => {
+            // The EXR format requires seekable output (Write + Seek), so stdout is not supported.
+            let output_file_path = args.output_file_path
+                .ok_or("EXR output requires a file path (stdout is not supported).")?;
+            let mut writer = File::create(&output_file_path)
+                .map_err(|e| format!("Failed to create output file: {}", e))?;
+            trace!("Writing output to file: {}", output_file_path);
 
-            let converter = AppleHdrHeicConverter::new(&bytes)
-                .map_err(|e| format!("Failed to create Apple HDR HEIC converter: {}", e))?;
+            match input_format {
+                InputFormat::Jpeg => {
+                    let uhdr_converter = UhdrConverter::new(&mut reader, args.max_display_boost)
+                        .map_err(|e| format!("Failed to create UHDR converter: {}", e))?;
 
-            converter.convert_to_avif(&mut writer, target_sdr_white_level, preserve_exif)
-                .map_err(|e| format!("Failed to convert Apple HDR HEIC to AVIF: {}", e))?;
+                    uhdr_converter.convert_to_exr(&mut writer, target_sdr_white_level)
+                        .map_err(|e| format!("Failed to convert UHDR JPEG to EXR: {}", e))?;
+                }
+                #[cfg(feature = "heif")]
+                InputFormat::Heic => {
+                    let mut bytes = Vec::new();
+                    reader.read_to_end(&mut bytes)
+                        .map_err(|e| format!("Failed to read input: {}", e))?;
+
+                    let converter = AppleHdrHeicConverter::new(&bytes)
+                        .map_err(|e| format!("Failed to create Apple HDR HEIC converter: {}", e))?;
+
+                    converter.convert_to_exr(&mut writer, target_sdr_white_level)
+                        .map_err(|e| format!("Failed to convert Apple HDR HEIC to EXR: {}", e))?;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Add EXR as a new output format writing BT.2020 linear float RGB (nits) with chromaticity metadata and PIZ compression via the `exr` crate.

- Rewrite `outexr.rs` with `FloatImageContent`-based API (`Write + Seek`)
- Extract `compute_hdr_linear_pixels` helper in both `UhdrConverter` and `AppleHdrHeicConverter`, add `convert_to_exr` methods (`exr` feature)
- Make `outexr` module public in `lib.rs`
- Add `exr` feature to `uhdr2avif` crate (default on, forwards to `libuhdr/exr`)
- Rename CLI `--format`/`-f` to `--input-format`/`-I`
- Add `--output-format`/`-F` with auto-detection from output file extension
- Update README and CLAUDE.md (copilot-instructions.md)